### PR TITLE
Update $packageVersionID from String! to ID!

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,7 @@ const run = async () => {
   `;
 
   const delete_package = `
-    mutation deletePackageVersion($package_id: String!) {
+    mutation deletePackageVersion($package_id: ID!) {
       deletePackageVersion(input: { packageVersionId: $package_id }) {
         success
       }


### PR DESCRIPTION
Update deletePackageVersion to use `ID` instead of `String` type

See fix https://github.com/SmartsquareGmbH/delete-old-packages/pull/22 from the original repo

Todo:
- [x] Bump version
- [x] Deploy new version